### PR TITLE
Updated GnewsGatherererror with handling and case-insensitive topic matching #

### DIFF
--- a/looksatwords/gatherer.py
+++ b/looksatwords/gatherer.py
@@ -119,8 +119,10 @@ class GnewsGatherer(Gatherer):
             articles.append(DataFrame(self.gnews.get_top_news()))
         if location is not None:
             articles.append(DataFrame(self.gnews.get_news_by_location(location)))
-        if topic is not None and topic in topics:
+        if topic is not None:
             topic = topic.upper()
+            if topic not in topics:
+                raise ValueError(f"Invalid topic '{topic}'. Valid topics are: {', '.join(topics)}")
             articles.append(DataFrame(self.gnews.get_news_by_topic(topic)))
         if site is not None:
             articles.append(DataFrame(self.gnews.get_news_by_site(site)))


### PR DESCRIPTION
(Now with the correct branch)

Previously, if an invalid topic was provided, it would still be used and no articles would be returned from the API.

Now, if an invalid topic is provided, a ValueError is raised with a message indicating the valid topics. Also added logic to convert lowercase values to uppercase, allowing 'world' or 'WORLD' to be provided as a variable.